### PR TITLE
Use new player for media and entrance with support for playing events when music is playing

### DIFF
--- a/Discord.BotABordelV2/Players/BotaPlayer.cs
+++ b/Discord.BotABordelV2/Players/BotaPlayer.cs
@@ -1,0 +1,77 @@
+using Lavalink4NET.Players;
+using Lavalink4NET.Players.Queued;
+using Lavalink4NET.Players.Vote;
+using Lavalink4NET.Protocol.Payloads.Events;
+using Lavalink4NET.Tracks;
+
+namespace Discord.BotABordelV2.Players;
+
+internal record SavedPlayingTrack(
+    LavalinkTrack Track,
+    TrackPosition Position
+);
+
+public sealed class BotaPlayer : VoteLavalinkPlayer
+{
+    public BotaPlayer(IPlayerProperties<BotaPlayer, VoteLavalinkPlayerOptions> properties) : base(properties)
+    {
+    }
+
+    private LavalinkTrack? _eventTrack;
+
+    private SavedPlayingTrack? _savedPlayingTrack;
+
+    public static ValueTask<BotaPlayer> CreatePlayerAsync(IPlayerProperties<BotaPlayer, VoteLavalinkPlayerOptions> properties, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(properties);
+
+        return ValueTask.FromResult(new BotaPlayer(properties));
+    }
+
+    public async Task PlayEventTrackAsync(LavalinkTrack track)
+    {
+        if (State == PlayerState.Playing)
+        {
+            _savedPlayingTrack = new(CurrentTrack!, Position!.Value);
+
+            await PauseAsync();
+        }
+
+        _eventTrack = track;
+        await PlayAsync(track, false);
+    }
+
+    protected override ValueTask NotifyTrackEndedAsync(ITrackQueueItem queueItem, TrackEndReason endReason, CancellationToken cancellationToken = default)
+    {
+        if (_eventTrack is not null && queueItem.Track == _eventTrack)
+        {
+            return HandleEventTrackEndedAsync();
+        }
+
+        return base.NotifyTrackEndedAsync(queueItem, endReason, cancellationToken);
+    }
+
+    private async ValueTask HandleEventTrackEndedAsync()
+    {
+        _eventTrack = null;
+
+        if (_savedPlayingTrack is not null)
+        {
+            await PlayAsync(
+                    _savedPlayingTrack.Track,
+                    false,
+                    new TrackPlayProperties
+                    {
+                        StartPosition = _savedPlayingTrack.Position.Position - TimeSpan.FromSeconds(0.5)
+                    });
+
+            _savedPlayingTrack = null;
+        }
+        else
+        {
+            await DisconnectAsync();
+            await DisposeAsync();
+        }
+    }
+}

--- a/Discord.BotABordelV2/Services/Media/LocalMediaService.cs
+++ b/Discord.BotABordelV2/Services/Media/LocalMediaService.cs
@@ -2,6 +2,7 @@
 
 using Lavalink4NET;
 using Lavalink4NET.Players;
+using Lavalink4NET.Players.Queued;
 using Lavalink4NET.Rest.Entities.Tracks;
 using Lavalink4NET.Tracks;
 
@@ -43,13 +44,13 @@ public class LocalMediaService : MediaService
     {
         try
         {
-            var player = await GetGrandEntrancePlayerAsync(channel);
+            var player = await GetPlayerAsync(channel);
 
             if (player is null)
                 return new PlayTrackResult(PlayTrackStatus.PlayerUnavailable);
 
             if (!File.Exists(track))
-                    throw new FileNotFoundException("Could not open find track at path", track);
+                throw new FileNotFoundException("Could not open find track at path", track);
 
             var loadedTrack = await _audioService.Tracks.LoadTrackAsync(
                 Path.GetFullPath(track),
@@ -58,16 +59,8 @@ public class LocalMediaService : MediaService
                     )
                 ) ?? throw new InvalidOperationException($"Track not found");
 
-            await player.PlayAsync(loadedTrack);
+            await player.PlayEventTrackAsync(loadedTrack);
             _logger.LogInformation("Playing track {track}", loadedTrack.Title);
-
-            while (player.State is PlayerState.Playing)
-            {
-                Thread.Sleep(1000);
-            }
-
-            await player.DisconnectAsync();
-            await player.DisposeAsync();
 
             return new PlayTrackResult(loadedTrack);
         }

--- a/Discord.BotABordelV2/Services/Media/StreamingMediaService.cs
+++ b/Discord.BotABordelV2/Services/Media/StreamingMediaService.cs
@@ -24,7 +24,7 @@ public class StreamingMediaService : MediaService, IMediaService
         if (string.IsNullOrEmpty(track))
             throw new ArgumentException($"'{nameof(track)}' cannot be null or empty.", nameof(track));
 
-        var player = await GetStandardPlayerAsync(channel)
+        var player = await GetPlayerAsync(channel)
             ?? throw new Exceptions.MediaExceptions.NullChannelConnectionException($"Channel connection to '{channel.Name}' failed");
 
         var foundTrack = await _audioService.Tracks.LoadTrackAsync(track, TrackSearchMode.YouTube);


### PR DESCRIPTION
Remove seperate GetPlayer method and create a new BotaPlayer inheriting VotePlayer

- Pauses tracks to play EntranceEvents and resume
- Keeps queue